### PR TITLE
Update interpreter to find node via PATH

### DIFF
--- a/bin/url-inspector.js
+++ b/bin/url-inspector.js
@@ -1,4 +1,4 @@
-#!/usr/bin/node
+#!/usr/bin/env node
 
 var dash = require('dashdash');
 var debug = require('debug')('url-inspector');


### PR DESCRIPTION
For portability, find `node` via `$PATH` instead of at hard-coded _/usr/bin/node_

If the user installs Node.js in a non-standard location, or is using a version manager, the expected path might not exist otherwise.
